### PR TITLE
Fix typo

### DIFF
--- a/src/components/ExampleCity/Steps.js
+++ b/src/components/ExampleCity/Steps.js
@@ -18,7 +18,7 @@ export default function Steps() {
               <StepCard
                 img={apo1}
                 // TODO: Change `Example City` to the name of your city
-                text="Sign up for a Counterspell Example City"
+                text="Sign up for Counterspell Example City"
               />
               <StepCard
                 img={apo2}


### PR DESCRIPTION
Change `Sign up for a Counterspell Example City` to `Sign up for Counterspell Example City`. Clarification that there's only a singular Counterspell happening in that city.