### PR TITLE
Modify registration API to use record ID from events table

### DIFF
--- a/pages/api/v1/[city]/register.js
+++ b/pages/api/v1/[city]/register.js
@@ -193,7 +193,7 @@ export default async function handler(req, res) {
       valid_cities: eventSlugs,
     });
   }
-  const linkedEventName = eventNames[eventSlugs.indexOf(city)];
+  const linkedEvent = events[eventSlugs.indexOf(city)];
 
   const errors = [];
   const warnings = [];
@@ -332,7 +332,7 @@ export default async function handler(req, res) {
   );
 
   body["Event Name"] = city;
-  body["Events Link"] = [linkedEventName];
+  body["Events Link"] = [linkedEvent.id];
 
   if (testing) {
     return res.json({


### PR DESCRIPTION
Modify the registration API to use the record ID from the "Events" table for the event link.

